### PR TITLE
【Fixed】rails g　で余計なファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,10 @@ module Kadai007Rails
     # the framework and any gems in your application.
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+    config.generators do |g|
+     g.javascripts false
+     g.helper false
+     g.test_framework false
+   end
   end
 end


### PR DESCRIPTION
#1 
・config>aplication.rbに記載追加
 config.generators do |g|
     g.javascripts false
     g.helper false
     g.test_framework false
   end